### PR TITLE
Implement testing for mail messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: bionic
 language: python
 
 python:
+    - 3.6
     - 3.7
+    - 3.8
 
 script: pytest

--- a/checklist_app/forms/__init__.py
+++ b/checklist_app/forms/__init__.py
@@ -1,7 +1,5 @@
 # flake8: noqa
 from .admin_forms import AddUserForm, EditUserForm
-from .auth_forms import (LoginForm, RegistrationForm,
-                                      SendPasswordChangeForm,
-                                      UpdatePasswordForm)
-from .checklist_forms import (AddItemForm, CreateListForm,
-                                           EditListForm)
+from .auth_forms import (LoginForm, RegistrationForm, SendPasswordChangeForm,
+                         UpdatePasswordForm)
+from .checklist_forms import AddItemForm, CreateListForm, EditListForm

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@
 import pytest
 from werkzeug.security import generate_password_hash
 
-from checklist_app import create_app, db, init_db
+from checklist_app import create_app, db, init_db, mail
 from checklist_app.models import AccountStatus, Checklist, User, get_user
 
 
@@ -39,6 +39,8 @@ def app():
         db.session.add(checklist)
         db.session.commit()
 
+        app.mail = mail
+
     yield app
 
 
@@ -52,6 +54,12 @@ def client(app):
 def runner(app):
     """Returns a runner for the tests."""
     return app.test_cli_runner()
+
+
+@pytest.fixture
+def outbox(app):
+    with app.mail.record_messages() as _outbox:
+        yield _outbox
 
 
 class AuthActions(object):


### PR DESCRIPTION
Pull Request to implement testing for email messages being send using `Flask-Mail`.

Additionally:
* Adds `python 3.6` and `python 3.8` to the Travis-CI build definitions
* Makes some minor adjustments to formatting for so imports.