### PR TITLE
Update progress calculation

### DIFF
--- a/checklist_app/models/checklist.py
+++ b/checklist_app/models/checklist.py
@@ -31,11 +31,12 @@ class Checklist(db.Model):
 
     @hybrid_property
     def percent_complete(self):
-        if len(self.items) == 0:
+        _active_items = [i for i in self.items if i.active]
+        if len(_active_items) == 0:
             return 0
 
-        done = sum([1 for i in self.items if i.done])
-        return done / len(self.items)
+        done = sum([1 for i in _active_items if i.done])
+        return done / len(_active_items)
 
     def record_change(self, description, user):
         _desc = f"{user.full_name} {description}"

--- a/tests/test_checklist.py
+++ b/tests/test_checklist.py
@@ -87,6 +87,17 @@ def test_unmark_item_done(app, client, auth):
         assert not item.done
 
 
+def test_delete_item(app, client, auth):
+    with app.app_context():
+        auth.login()
+        response = client.get('/checklist/1/delete/1')
+        assert response.status_code == 302
+        assert '/checklist/1' in response.headers['Location']
+
+        checklist = Checklist.query.get(1)
+        assert checklist.percent_complete == 0.5
+
+
 def test_mark_all_items_done(app, client, auth):
     with app.app_context():
         auth.login()
@@ -107,9 +118,7 @@ def test_delete_checklist(app, client, auth):
         assert b'Delete' in response.data
 
         # Simulate clicking the button and check that the form is deleted
-        data = {
-            "confirm_delete": "1"
-        }
+        data = {"confirm_delete": "1"}
         response = client.post('/checklist/delete/1', data=data)
         # redirects to the listing
         assert response.status_code == 302


### PR DESCRIPTION
Close #47 

The calculation of progress was wrong because it counted all items including those that had been deleted. This PR changes the `percent_complete` property so that it uses only active items.